### PR TITLE
Add Pub/Sub and GCS IAM bindings plus support for user-managed Dataflow worker service account

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ Deployment templates include an optional Cloud Monitoring custom dashboard to mo
 ### Permissions Required
 
 At a minimum, you must have the following roles before you deploy the resources in this Terraform:
-- Logs Configuration Writer (`roles/logging.configWriter`) at the project level (and optionally organization-level)
+- Logs Configuration Writer (`roles/logging.configWriter`) at the project and/or organization level
 - Compute Network Admin (`roles/compute.networkAdmin`) at the project level
 - Compute Security Admin (`roles/compute.securityAdmin`) at the project level
 - Dataflow Admin (`roles/dataflow.admin`) at the project level
 - Pub/Sub Admin (`roles/pubsub.admin`) at the project level
 - Storage Admin (`roles/storage.admin`) at the project level
 
-To ensure proper pipeline operation, Terraform creates necessary IAM bindings at the resource level as part of this deployment to grant access between newly created resources. For example, Log sink writer is granted Pub/Sub Publisher role over the input topic which aggregates all the logs, and Dataflow worker service account is granted both Pub/Sub subscriber over the inupt subscription, and Pub/Sub Publisher role over the deadletter topic.
+To ensure proper pipeline operation, Terraform creates necessary IAM bindings at the resources level as part of this deployment to grant access between newly created resources. For example, Log sink writer is granted Pub/Sub Publisher role over the input topic which collects all the logs, and Dataflow worker service account is granted both Pub/Sub subscriber over the input subscription, and Pub/Sub Publisher role over the deadletter topic.
 
-**Note about Dataflow permissions**: You must have permission to impersonate Dataflow worker service account (which executes pipeline operations) in order to attach that service account to Compute Engine VMs.  In case of default worker service account (i.e. Compute Engine default service account), ensure you have `iam.serviceAccounts.actAs` permission over your project's Compute Engine default service account. For security purposes, this Terraform does not modify access to that existing Compute Engine's default service account due to potentially inheriting broad permissions. On the other hand, if you choose to use a user-managed worker service account (by setting `dataflow_worker_service_account` template parameter), Terraform will add necessary permission over the new service account. The former approach, i.e. user-managed service account, is recommended in order to use a minimally-scoped service account dedicated for this pipeline, and to have impersonation permission managed for you by this Terraform.
+**Note about Dataflow permissions**: You must also have permission to impersonate Dataflow worker service account in order to attach that service account to Compute Engine VMs which will execute pipeline operations. In case of default worker service account (i.e. your project's Compute Engine default service account), ensure you have `iam.serviceAccounts.actAs` permission over Compute Engine default service account in your project. For security purposes, this Terraform does not modify access to your existing Compute Engine default service account due to risk of granting broad permissions. On the other hand, if you choose to use a user-managed worker service account (by setting `dataflow_worker_service_account` template parameter), this Terraform will add necessary permission over the new service account. The former approach, i.e. user-managed service account, is recommended in order to use a minimally-scoped service account dedicated for this pipeline, and to have impersonation permission managed for you by this Terraform.
 
 See [Security and permissions for pipelines](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#security_and_permissions_for_pipelines_on) to learn more about Dataflow service accounts and their permissions.
  

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ dataflow_job_disable_certificate_validation | (Optional) Boolean to disable SSL 
 dataflow_job_udf_gcs_path | (Optional) GCS path for JavaScript file (default No UDF used)
 dataflow_job_udf_function_name | (Optional) Name of JavaScript function to be called (default No UDF used)
 dataflow_template_version | (Optional) Dataflow template release version (default 'latest'). Override this for version pinning e.g. '2021-08-02-00_RC00'. Must specify version only since template GCS path will be deduced automatically: 'gs://dataflow-templates/`version`/Cloud_PubSub_to_Splunk'
+dataflow_worker_service_account | (Optional) Name of worker service account to be created and used to execute job operations. Must be 6-30 characters long, and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])`. See [`account_id`](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/google_service_account#account_id) for more details on expected format. If parameter is empty, worker service account defaults to project's Compute Engine default service account.
 
 ### Monitoring Dashboard (Batteries Included)
 
@@ -54,6 +55,22 @@ Before deploying the Terraform in a Google Cloud Platform Project, the following
 
 For information on enabling Google Cloud Platform APIs, please see [Getting Started: Enabling APIs](https://cloud.google.com/apis/docs/getting-started#enabling_apis).
 
+#### Permissions required
+
+At a minimum, you must have the following roles before you deploy the resources in this Terraform:
+- Logs Configuration Writer (`roles/logging.configWriter`) at the project level (and optionally organization-level)
+- Compute Network Admin (`roles/compute.networkAdmin`) at the project level
+- Compute Security Admin (`roles/compute.securityAdmin`) at the project level
+- Dataflow Admin (`roles/dataflow.admin`) at the project level
+- Pub/Sub Admin (`roles/pubsub.admin`) at the project level
+- Storage Admin (`roles/storage.admin`) at the project level
+
+To ensure proper pipeline operation, Terraform creates necessary IAM bindings at the resource level as part of this deployment to grant access between newly created resources. For example, Log sink writer is granted Pub/Sub Publisher role over the input topic which aggregates all the logs, and Dataflow worker service account is granted both Pub/Sub subscriber over the inupt subscription, and Pub/Sub Publisher role over the deadletter topic.
+
+**Note about Dataflow permissions**: You must have permission to impersonate Dataflow worker service account (which executes pipeline operations) in order to attach that service account to Compute Engine VMs.  In case of default worker service account (i.e. Compute Engine default service account), ensure you have `iam.serviceAccounts.actAs` permission over your project's Compute Engine default service account. For security purposes, this Terraform does not modify access to that existing Compute Engine's default service account due to potentially inheriting broad permissions. On the other hand, if you choose to use a user-managed worker service account (by setting `dataflow_worker_service_account` template parameter), Terraform will add necessary permission over the service account. The former approach, that is the user-managed service account, is recommended in order to use a minimally-scoped service account dedicated for this pipeline, where permissions to impersonate are also managed for you in this Terraform.
+
+See [Security and permissions for pipelines](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#security_and_permissions_for_pipelines_on) to learn more about managing Dataflow permissions.
+ 
 #### Setup working directory
 
 1. Copy placeholder vars file `variables.yaml` into new `terraform.tfvars` to hold your own settings.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ dataflow_worker_service_account | (Optional) Name of worker service account to b
 Deployment templates include an optional Cloud Monitoring custom dashboard to monitor your log export operations:
 ![Ops Dashboard of Log Export to Splunk](./images/logging_export_ops_dashboard.png)
 
+### Permissions Required
+
+At a minimum, you must have the following roles before you deploy the resources in this Terraform:
+- Logs Configuration Writer (`roles/logging.configWriter`) at the project level (and optionally organization-level)
+- Compute Network Admin (`roles/compute.networkAdmin`) at the project level
+- Compute Security Admin (`roles/compute.securityAdmin`) at the project level
+- Dataflow Admin (`roles/dataflow.admin`) at the project level
+- Pub/Sub Admin (`roles/pubsub.admin`) at the project level
+- Storage Admin (`roles/storage.admin`) at the project level
+
+To ensure proper pipeline operation, Terraform creates necessary IAM bindings at the resource level as part of this deployment to grant access between newly created resources. For example, Log sink writer is granted Pub/Sub Publisher role over the input topic which aggregates all the logs, and Dataflow worker service account is granted both Pub/Sub subscriber over the inupt subscription, and Pub/Sub Publisher role over the deadletter topic.
+
+**Note about Dataflow permissions**: You must have permission to impersonate Dataflow worker service account (which executes pipeline operations) in order to attach that service account to Compute Engine VMs.  In case of default worker service account (i.e. Compute Engine default service account), ensure you have `iam.serviceAccounts.actAs` permission over your project's Compute Engine default service account. For security purposes, this Terraform does not modify access to that existing Compute Engine's default service account due to potentially inheriting broad permissions. On the other hand, if you choose to use a user-managed worker service account (by setting `dataflow_worker_service_account` template parameter), Terraform will add necessary permission over the new service account. The former approach, i.e. user-managed service account, is recommended in order to use a minimally-scoped service account dedicated for this pipeline, and to have impersonation permission managed for you by this Terraform.
+
+See [Security and permissions for pipelines](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#security_and_permissions_for_pipelines_on) to learn more about Dataflow service accounts and their permissions.
+ 
 ### Getting Started
 
 #### Requirements
@@ -55,22 +71,6 @@ Before deploying the Terraform in a Google Cloud Platform Project, the following
 
 For information on enabling Google Cloud Platform APIs, please see [Getting Started: Enabling APIs](https://cloud.google.com/apis/docs/getting-started#enabling_apis).
 
-#### Permissions required
-
-At a minimum, you must have the following roles before you deploy the resources in this Terraform:
-- Logs Configuration Writer (`roles/logging.configWriter`) at the project level (and optionally organization-level)
-- Compute Network Admin (`roles/compute.networkAdmin`) at the project level
-- Compute Security Admin (`roles/compute.securityAdmin`) at the project level
-- Dataflow Admin (`roles/dataflow.admin`) at the project level
-- Pub/Sub Admin (`roles/pubsub.admin`) at the project level
-- Storage Admin (`roles/storage.admin`) at the project level
-
-To ensure proper pipeline operation, Terraform creates necessary IAM bindings at the resource level as part of this deployment to grant access between newly created resources. For example, Log sink writer is granted Pub/Sub Publisher role over the input topic which aggregates all the logs, and Dataflow worker service account is granted both Pub/Sub subscriber over the inupt subscription, and Pub/Sub Publisher role over the deadletter topic.
-
-**Note about Dataflow permissions**: You must have permission to impersonate Dataflow worker service account (which executes pipeline operations) in order to attach that service account to Compute Engine VMs.  In case of default worker service account (i.e. Compute Engine default service account), ensure you have `iam.serviceAccounts.actAs` permission over your project's Compute Engine default service account. For security purposes, this Terraform does not modify access to that existing Compute Engine's default service account due to potentially inheriting broad permissions. On the other hand, if you choose to use a user-managed worker service account (by setting `dataflow_worker_service_account` template parameter), Terraform will add necessary permission over the service account. The former approach, that is the user-managed service account, is recommended in order to use a minimally-scoped service account dedicated for this pipeline, where permissions to impersonate are also managed for you in this Terraform.
-
-See [Security and permissions for pipelines](https://cloud.google.com/dataflow/docs/concepts/security-and-permissions#security_and_permissions_for_pipelines_on) to learn more about managing Dataflow permissions.
- 
 #### Setup working directory
 
 1. Copy placeholder vars file `variables.yaml` into new `terraform.tfvars` to hold your own settings.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Deployment templates include an optional Cloud Monitoring custom dashboard to mo
 
 #### Requirements
 * Terraform 0.13+
+* Splunk Dataflow template 2022-04-25-00_RC00 or later
 
 #### Enabling APIs
 Before deploying the Terraform in a Google Cloud Platform Project, the following APIs must be enabled:

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,8 @@ locals {
 
   # dataflow job parameters (not externalized for this project)
   dataflow_job_include_pubsub_message = true
+  dataflow_job_enable_batch_logs = false
+  dataflow_job_enable_gzip_http_compression = true
 }
 
 resource "google_pubsub_topic" "dataflow_input_pubsub_topic" {

--- a/main.tf
+++ b/main.tf
@@ -21,6 +21,10 @@ provider "google" {
   region  = var.region
 }
 
+data "google_project" "project" {}
+
+data "google_client_openid_userinfo" "provider_identity" {}
+
 # Generate new random hex to be used for bucket name
 resource "random_id" "bucket_suffix" {
   byte_length = 4
@@ -41,6 +45,12 @@ locals {
 
   dataflow_splunk_template_gcs_path = "gs://dataflow-templates/${var.dataflow_template_version}/Cloud_PubSub_to_Splunk"
   dataflow_pubsub_template_gcs_path = "gs://dataflow-templates/${var.dataflow_template_version}/Cloud_PubSub_to_Cloud_PubSub"
+
+  # If provided, set Dataflow worker to new user-managed service account;
+  # otherwise, use Compute Engine default service account
+  dataflow_worker_service_account = ((var.dataflow_worker_service_account != "")
+    ? "${var.dataflow_worker_service_account}"
+    : "${data.google_project.project.number}-compute@developer.gserviceaccount.com")
 
   subnet_name = coalesce(var.subnet, "${var.network}-${var.region}")
   project_log_sink_name = "${var.dataflow_job_name}-project-log-sink"
@@ -94,15 +104,6 @@ resource "google_logging_project_sink" "project_log_sink" {
 #
 #   include_children = "true"
 # }
-
-resource "google_pubsub_topic_iam_binding" "pubsub_iam_binding" {
-  project = google_pubsub_topic.dataflow_input_pubsub_topic.project
-  topic = google_pubsub_topic.dataflow_input_pubsub_topic.name
-  role = "roles/pubsub.publisher"
-  members = [
-    google_logging_project_sink.project_log_sink.writer_identity,
-  ]
-}
 
 output "dataflow_job_id" {
     value = google_dataflow_job.dataflow_job.job_id

--- a/permissions.tf
+++ b/permissions.tf
@@ -1,0 +1,74 @@
+# Copyright 2022 Google LLC
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#     https://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_pubsub_topic_iam_binding" "input_sub_publisher" {
+  project = google_pubsub_topic.dataflow_input_pubsub_topic.project
+  topic = google_pubsub_topic.dataflow_input_pubsub_topic.name
+  role = "roles/pubsub.publisher"
+  members = [
+    google_logging_project_sink.project_log_sink.writer_identity
+  ]
+}
+
+resource "google_pubsub_subscription_iam_binding" "input_sub_subscriber" {
+  project = google_pubsub_subscription.dataflow_input_pubsub_subscription.project
+  subscription = google_pubsub_subscription.dataflow_input_pubsub_subscription.name
+  role = "roles/pubsub.subscriber"
+  members = [
+    "serviceAccount:${local.dataflow_worker_service_account}"
+  ]
+}
+
+resource "google_pubsub_topic_iam_binding" "deadletter_topic_publisher" {
+  project = google_pubsub_topic.dataflow_deadletter_pubsub_topic.project
+  topic = google_pubsub_topic.dataflow_deadletter_pubsub_topic.name
+  role = "roles/pubsub.publisher"
+  members = [
+    "serviceAccount:${local.dataflow_worker_service_account}"
+  ]
+}
+
+resource "google_storage_bucket_iam_binding" "dataflow_worker_bucket_access" {
+  bucket = google_storage_bucket.dataflow_job_temp_bucket.name
+  role = "roles/storage.objectAdmin"
+  members = [
+    "serviceAccount:${local.dataflow_worker_service_account}"
+  ]
+}
+
+resource "google_project_iam_binding" "dataflow_worker_role" {
+  project = var.project
+  role = "roles/dataflow.worker"
+  members = [
+    "serviceAccount:${local.dataflow_worker_service_account}"
+  ]
+}
+
+# To deploy Dataflow jobs, terraform caller identity must have permission to impersonate
+# worker service account in order to attach that service account to Compute Engine VMs.
+# In case of user-managed worker service account, add necessary permission over new service account,
+# (id: google_service_account.dataflow_worker_service_account[0].id)
+# In case of default worker service account (i.e. Compute Engine default service account), caller
+# must have permission to impersonate Compute Engine default service account; otherwise, job
+# deployment will return an error. For security purposes, we do not modify access to existing
+# default Compute Engine service account
+resource "google_service_account_iam_binding" "terraform_caller_impersonate_dataflow_worker" {
+  count = (var.dataflow_worker_service_account != "") ? 1 : 0
+  service_account_id = google_service_account.dataflow_worker_service_account[0].id
+  role = "roles/iam.serviceAccountUser"
+
+  members = [
+      "user:${data.google_client_openid_userinfo.provider_identity.email}"
+  ]
+}

--- a/pipeline.tf
+++ b/pipeline.tf
@@ -42,10 +42,17 @@ resource "google_storage_bucket_object" "dataflow_job_temp_object" {
   bucket = google_storage_bucket.dataflow_job_temp_bucket.name
 }
 
+resource "google_service_account" "dataflow_worker_service_account" {
+  count = (var.dataflow_worker_service_account != "") ? 1 : 0
+  account_id = var.dataflow_worker_service_account
+  display_name =  "Dataflow worker service account to execute pipeline operations"
+}
+
 resource "google_dataflow_job" "dataflow_job" {
   name = local.dataflow_main_job_name
   template_gcs_path = local.dataflow_splunk_template_gcs_path
   temp_gcs_location = "gs://${local.dataflow_temporary_gcs_bucket_name}/${local.dataflow_temporary_gcs_bucket_path}"
+  service_account_email = local.dataflow_worker_service_account
   machine_type = var.dataflow_job_machine_type
   max_workers = var.dataflow_job_machine_count
   parameters = merge({

--- a/pipeline.tf
+++ b/pipeline.tf
@@ -57,6 +57,8 @@ resource "google_dataflow_job" "dataflow_job" {
     batchCount = var.dataflow_job_batch_count
     includePubsubMessage = local.dataflow_job_include_pubsub_message
     disableCertificateValidation = var.dataflow_job_disable_certificate_validation
+    enableBatchLogs = local.dataflow_job_enable_batch_logs                          # Supported as of 2022-03-21-00_RC01
+    enableGzipHttpCompression = local.dataflow_job_enable_gzip_http_compression     # Supported as of 2022-04-25-00_RC00
   },
     (var.dataflow_job_udf_gcs_path != "" && var.dataflow_job_udf_function_name != "") ?
     {

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,18 @@ variable "dataflow_template_version" {
   default     = "latest"
 }
 
+variable "dataflow_worker_service_account" {
+  type        = string
+  description = "(Optional) Name of worker service account to be created and used to execute job operations. Must be 6-30 characters long, and match the regular expression [a-z]([-a-z0-9]*[a-z0-9]). If parameter is empty, worker service account defaults to project's Compute Engine default service account."
+  default     = ""
+
+  validation {
+    condition = (var.dataflow_worker_service_account == "" ||
+                can(regex("[a-z]([-a-z0-9]*[a-z0-9]", var.dataflow_worker_service_account)))
+    error_message = "Dataflow worker service account id must match the regular expression [a-z]([-a-z0-9]*[a-z0-9])."
+  }
+}
+
 variable "dataflow_job_name" {
   description = "Dataflow job name. No spaces"
 }


### PR DESCRIPTION
- Automatically create necessary IAM bindings at the resource level (Pub/Sub publisher and subscriber, Storage bucket access) and project level (Dataflow worker).
- Optionally create a minimally-scoped service account to use as user-managed Dataflow worker service account. Otherwise, default to project's Compute Engine default service account.