### PR TITLE
Removed provider definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The project is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Option `use_externally_managed_dataflow_sa` to be able to use pre-existing externally-managed service account as Dataflow worker service account. User is expected to apply and manage IAM permissions over external resources (e.g. Cloud KMS key or Secret version) outside of this module.
 
+### Removed
+
+- `provider configuration` because it is causing issues of usage with `count` and `for_each`
+
 <a name="v1.0.0"></a>
 ## [v1.0.0] - 2022-12-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The project is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Removed
 
-- `provider configuration` because it is causing issues of usage with `count` and `for_each`
+- `providers` configuration because it prevents usage of this module with `count` and `for_each`. This module now inherits the default provider configuration from the caller, thereby simplifying module re-usability.
 
 <a name="v1.0.0"></a>
 ## [v1.0.0] - 2022-12-20

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-data "google_project" "project" {}
+data "google_project" "project" {
+  project_id = var.project
+}
 
 data "google_client_openid_userinfo" "provider_identity" {}
 
@@ -89,12 +91,14 @@ locals {
 }
 
 resource "google_pubsub_topic" "dataflow_input_pubsub_topic" {
-  name = local.dataflow_input_topic_name
+  project = var.project
+  name    = local.dataflow_input_topic_name
 }
 
 resource "google_pubsub_subscription" "dataflow_input_pubsub_subscription" {
-  name  = local.dataflow_input_subscription_name
-  topic = google_pubsub_topic.dataflow_input_pubsub_topic.name
+  project = var.project
+  name    = local.dataflow_input_subscription_name
+  topic   = google_pubsub_topic.dataflow_input_pubsub_topic.name
 
   # messages retained for 7 days (max)
   message_retention_duration = "604800s"
@@ -107,6 +111,7 @@ resource "google_pubsub_subscription" "dataflow_input_pubsub_subscription" {
 }
 
 resource "google_logging_project_sink" "project_log_sink" {
+  project     = var.project
   name        = local.project_log_sink_name
   destination = "pubsub.googleapis.com/projects/${var.project}/topics/${google_pubsub_topic.dataflow_input_pubsub_topic.name}"
   filter      = var.log_filter

--- a/network.tf
+++ b/network.tf
@@ -1,6 +1,7 @@
 resource "google_compute_network" "splunk_export" {
   count = var.create_network == true ? 1 : 0
 
+  project                 = var.project
   name                    = var.network
   auto_create_subnetworks = false
 }
@@ -8,6 +9,7 @@ resource "google_compute_network" "splunk_export" {
 resource "google_compute_subnetwork" "splunk_subnet" {
   count = var.create_network == true ? 1 : 0
 
+  project                  = var.project
   name                     = local.subnet_name
   ip_cidr_range            = var.primary_subnet_cidr
   region                   = var.region
@@ -27,7 +29,8 @@ resource "google_compute_subnetwork" "splunk_subnet" {
 resource "google_dns_policy" "splunk_network_dns_policy" {
   count = var.create_network == true ? 1 : 0
 
-  name = "${var.network}-dns-policy"
+  project = var.project
+  name    = "${var.network}-dns-policy"
 
   enable_logging = true
 
@@ -39,6 +42,7 @@ resource "google_dns_policy" "splunk_network_dns_policy" {
 resource "google_compute_router" "dataflow_to_splunk_router" {
   count = var.create_network == true ? 1 : 0
 
+  project = var.project
   name    = "${var.network}-${var.region}-router"
   region  = google_compute_subnetwork.splunk_subnet[count.index].region
   network = google_compute_network.splunk_export[count.index].id
@@ -47,13 +51,15 @@ resource "google_compute_router" "dataflow_to_splunk_router" {
 resource "google_compute_address" "dataflow_nat_ip_address" {
   count = var.create_network == true ? 1 : 0
 
-  name   = "dataflow-splunk-nat-ip-address"
-  region = google_compute_subnetwork.splunk_subnet[count.index].region
+  project = var.project
+  name    = "dataflow-splunk-nat-ip-address"
+  region  = google_compute_subnetwork.splunk_subnet[count.index].region
 }
 
 resource "google_compute_router_nat" "dataflow_nat" {
   count = var.create_network == true ? 1 : 0
 
+  project                            = var.project
   name                               = "${var.network}-${var.region}-router-nat"
   router                             = google_compute_router.dataflow_to_splunk_router[count.index].name
   region                             = google_compute_router.dataflow_to_splunk_router[count.index].region
@@ -77,6 +83,7 @@ resource "google_compute_router_nat" "dataflow_nat" {
 resource "google_compute_firewall" "connect_dataflow_workers" {
   count = var.create_network == true ? 1 : 0
 
+  project = var.project
   name    = "dataflow-internal-ip-fwr"
   network = google_compute_network.splunk_export[count.index].id
 

--- a/pipeline.tf
+++ b/pipeline.tf
@@ -14,12 +14,14 @@
 
 
 resource "google_pubsub_topic" "dataflow_deadletter_pubsub_topic" {
-  name = local.dataflow_output_deadletter_topic_name
+  project = var.project
+  name    = local.dataflow_output_deadletter_topic_name
 }
 
 resource "google_pubsub_subscription" "dataflow_deadletter_pubsub_sub" {
-  name  = local.dataflow_output_deadletter_sub_name
-  topic = google_pubsub_topic.dataflow_deadletter_pubsub_topic.name
+  project = var.project
+  name    = local.dataflow_output_deadletter_sub_name
+  topic   = google_pubsub_topic.dataflow_deadletter_pubsub_topic.name
 
   # messages retained for 7 days (max)
   message_retention_duration = "604800s"
@@ -31,6 +33,7 @@ resource "google_pubsub_subscription" "dataflow_deadletter_pubsub_sub" {
 }
 
 resource "google_storage_bucket" "dataflow_job_temp_bucket" {
+  project       = var.project
   name          = local.dataflow_temporary_gcs_bucket_name
   location      = var.region
   storage_class = "REGIONAL"
@@ -44,11 +47,13 @@ resource "google_storage_bucket_object" "dataflow_job_temp_object" {
 
 resource "google_service_account" "dataflow_worker_service_account" {
   count        = (var.dataflow_worker_service_account != "" && var.use_externally_managed_dataflow_sa == false) ? 1 : 0
+  project      = var.project
   account_id   = var.dataflow_worker_service_account
   display_name = "Dataflow worker service account to execute pipeline operations"
 }
 
 resource "google_dataflow_job" "dataflow_job" {
+  project               = var.project
   name                  = local.dataflow_main_job_name
   template_gcs_path     = local.dataflow_splunk_template_gcs_path
   temp_gcs_location     = "gs://${local.dataflow_temporary_gcs_bucket_name}/${local.dataflow_temporary_gcs_bucket_path}"

--- a/providers.tf
+++ b/providers.tf
@@ -1,4 +1,0 @@
-provider "google" {
-  project = var.project
-  region  = var.region
-}


### PR DESCRIPTION
As per Hashicorp recommendations it is recommended to have `provider` definition only on the root level, not in the module.
There are some exceptions for that, but seems that is not the case.
https://developer.hashicorp.com/terraform/language/meta-arguments/module-providers#when-to-specify-providers

Error example:
```
Error: Module does not support count

  on main.tf line 7, in module "log_shipping_to_splunk":
   7:   count = true == false ? 1 : 0

Module "log_shipping_to_splunk" cannot be used with count because it contains
a nested provider configuration for "google", at
.terraform/modules/log_shipping_to_splunk/providers.tf:1,10-18.

This module can be made compatible with count by changing it to receive all of
its provider configurations from the calling module, by using the "providers"
argument in the calling module block.
```