### PR TITLE
Fix for missing project error

### DIFF
--- a/replay.tf
+++ b/replay.tf
@@ -23,6 +23,7 @@ run a regular terraform deployment (ex. terraform apply).
 resource "google_dataflow_job" "splunk_dataflow_replay" {
   count = var.deploy_replay_job == true ? 1 : 0
 
+  project           = var.project
   name              = local.dataflow_replay_job_name
   template_gcs_path = local.dataflow_pubsub_template_gcs_path
   temp_gcs_location = "gs://${local.dataflow_temporary_gcs_bucket_name}/${local.dataflow_temporary_gcs_bucket_path}"


### PR DESCRIPTION
If an explicit project has not been set in the GCP provider configuration or GCP SDK environment variable, you will receive the following error when attempting to run the replay pipeline:

google_dataflow_job.splunk_dataflow_replay[0]: Creating...

```
│ Error: project: required field is not set
│
│   with google_dataflow_job.splunk_dataflow_replay[0],
│   on replay.tf line 23, in resource "google_dataflow_job" "splunk_dataflow_replay":
│   23: resource "google_dataflow_job" "splunk_dataflow_replay" {
│
```

This PR removes this requirement and leverages the already required project variable set in the configuration variables. 