### PR TITLE
feat: enabling deploying dataflow workers to subnets in a Shared VPC

### DIFF
--- a/pipeline.tf
+++ b/pipeline.tf
@@ -98,9 +98,10 @@ resource "google_dataflow_job" "dataflow_job" {
       tokenSecretId = local.splunk_hec_token_secret_version_id # Supported as of 2022-03-14-00_RC00
     } : {},
   )
-  region           = var.region
-  network          = var.network
-  subnetwork       = "regions/${var.region}/subnetworks/${local.subnet_name}"
+  region  = var.region
+  network = var.network
+  # https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataflow_job#subnetwork
+  subnetwork       = "https://www.googleapis.com/compute/v1/projects/${var.vpc_project}/regions/${var.region}/subnetworks/${local.subnet_name}"
   ip_configuration = "WORKER_IP_PRIVATE"
 
   lifecycle {

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,10 @@ variable "project" {
   description = "Project ID to deploy resources in"
 }
 
+variable "vpc_project" {
+  description = "The name of the host project that owns the shared VPC/subnets"
+}
+
 variable "region" {
   type        = string
   description = "Region to deploy regional-resources into. This must match subnet's region if deploying into existing network (e.g. Shared VPC). See `subnet` parameter below"


### PR DESCRIPTION
Per: https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/dataflow_job#subnetwork

If we wanted to deploy the Dataflow workers in subnets in a Shared VPC model