### PR TITLE
Add option to use an organization sink

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -111,6 +111,8 @@ resource "google_pubsub_subscription" "dataflow_input_pubsub_subscription" {
 }
 
 resource "google_logging_project_sink" "project_log_sink" {
+  count = var.organization_id == null ? 1 : 0
+
   project     = var.project
   name        = local.project_log_sink_name
   destination = "pubsub.googleapis.com/projects/${var.project}/topics/${google_pubsub_topic.dataflow_input_pubsub_topic.name}"
@@ -125,11 +127,19 @@ resource "google_logging_project_sink" "project_log_sink" {
   unique_writer_identity = true
 }
 
-# resource "google_logging_organization_sink" "organization_log_sink" {
-#   name = local.organization_log_sink_name
-#   org_id = "ORGANIZATION_ID"
-#   destination = "pubsub.googleapis.com/projects/${var.project}/topics/${google_pubsub_topic.dataflow_input_pubsub_topic.name}"
-#   filter = var.log_filter
-#
-#   include_children = "true"
-# }
+resource "google_logging_organization_sink" "organization_log_sink" {
+  count = var.organization_id != null ? 1 : 0
+
+  name = local.organization_log_sink_name
+  org_id = var.organization_id
+  destination = "pubsub.googleapis.com/projects/${var.project}/topics/${google_pubsub_topic.dataflow_input_pubsub_topic.name}"
+  filter = var.log_filter
+
+  exclusions {
+    name        = "exclude_dataflow"
+    description = "Exclude dataflow logs to not create an infinite loop"
+    filter      = "resource.type=\"dataflow_step\" AND resource.labels.job_name = \"${local.dataflow_main_job_name}\""
+  }
+
+  include_children = "true"
+}

--- a/permissions.tf
+++ b/permissions.tf
@@ -12,13 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  members = compact([
+    try(google_logging_project_sink.project_log_sink[0].writer_identity, null),
+    try(google_logging_organization_sink.organization_log_sink[0].writer_identity, null)
+  ])
+}
+
 resource "google_pubsub_topic_iam_binding" "input_sub_publisher" {
+  count  = var.organization_id != null ? 1 : 0
+
   project = google_pubsub_topic.dataflow_input_pubsub_topic.project
   topic   = google_pubsub_topic.dataflow_input_pubsub_topic.name
   role    = "roles/pubsub.publisher"
-  members = [
-    google_logging_project_sink.project_log_sink.writer_identity
-  ]
+  members = local.members
+}
+
+resource "google_pubsub_topic_iam_binding" "input_sub_publisher_org" {
+  count  = var.organization_id == null ? 1 : 0
+
+  project = google_pubsub_topic.dataflow_input_pubsub_topic.project
+  topic   = google_pubsub_topic.dataflow_input_pubsub_topic.name
+  role    = "roles/pubsub.publisher"
+  members = local.members
 }
 
 resource "google_pubsub_subscription_iam_binding" "input_sub_subscriber" {

--- a/permissions.tf
+++ b/permissions.tf
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 locals {
-  members = compact([
-    try(google_logging_project_sink.project_log_sink[0].writer_identity, null),
-    try(google_logging_organization_sink.organization_log_sink[0].writer_identity, null)
-  ])
+  members = [
+    try(google_logging_organization_sink.organization_log_sink[0].writer_identity,
+        google_logging_project_sink.project_log_sink[0].writer_identity)
+  ]
 }
 
 resource "google_pubsub_topic_iam_binding" "input_sub_publisher" {

--- a/permissions.tf
+++ b/permissions.tf
@@ -12,29 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-locals {
+resource "google_pubsub_topic_iam_binding" "input_sub_publisher" {
+  project = google_pubsub_topic.dataflow_input_pubsub_topic.project
+  topic   = google_pubsub_topic.dataflow_input_pubsub_topic.name
+  role    = "roles/pubsub.publisher"
   members = [
     try(google_logging_organization_sink.organization_log_sink[0].writer_identity,
         google_logging_project_sink.project_log_sink[0].writer_identity)
   ]
-}
-
-resource "google_pubsub_topic_iam_binding" "input_sub_publisher" {
-  count  = var.organization_id != null ? 1 : 0
-
-  project = google_pubsub_topic.dataflow_input_pubsub_topic.project
-  topic   = google_pubsub_topic.dataflow_input_pubsub_topic.name
-  role    = "roles/pubsub.publisher"
-  members = local.members
-}
-
-resource "google_pubsub_topic_iam_binding" "input_sub_publisher_org" {
-  count  = var.organization_id == null ? 1 : 0
-
-  project = google_pubsub_topic.dataflow_input_pubsub_topic.project
-  topic   = google_pubsub_topic.dataflow_input_pubsub_topic.name
-  role    = "roles/pubsub.publisher"
-  members = local.members
 }
 
 resource "google_pubsub_subscription_iam_binding" "input_sub_subscriber" {

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "create_network" {
   type        = bool
 }
 
+variable "organization_id" {
+  description = "Organization ID to deploy organization sink instead of project sink"
+  type = string
+  default = null
+}
+
 variable "network" {
   description = "Network to deploy into"
   type        = string


### PR DESCRIPTION
I was following the documentation at the links below which references this repo:
- https://cloud.google.com/architecture/stream-logs-from-google-cloud-to-splunk
- https://cloud.google.com/architecture/stream-logs-from-google-cloud-to-splunk/deployment
The steps outlined are for an organization sink which I believe is the best option for organizations looking to capture everything within an organization.

